### PR TITLE
feat(liftosaur-sync): add syncIntervals option and enable hourly sync

### DIFF
--- a/hosts/osgiliath/services.nix
+++ b/hosts/osgiliath/services.nix
@@ -217,6 +217,7 @@
     liftosaur-sync = {
       enable = true;
       environmentFile = config.age.secrets.liftosaur-sync-env.path;
+      syncIntervals = "hourly";
     };
 
     frigate = {

--- a/services/liftosaur-sync.nix
+++ b/services/liftosaur-sync.nix
@@ -24,6 +24,11 @@ in
       type = types.path;
       description = "Path to the age-decrypted environment file containing API secrets (LIFTOSAUR_API_KEY, INTERVALS_API_KEY, STRAVA_CLIENT_ID, etc.).";
     };
+    syncIntervals = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "systemd calendar expression for periodic sync (e.g. \"hourly\" or \"*:0/30\"). null disables the timer.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -32,6 +37,7 @@ in
       port = globalVars.ports.liftosaur-sync;
       baseUrl = "https://${cfg.domain}";
       environmentFile = cfg.environmentFile;
+      syncIntervals = cfg.syncIntervals;
     };
 
     agindin.services.caddy.proxyHosts = mkIf config.agindin.services.caddy.enable [


### PR DESCRIPTION
## Summary
- Exposes `syncIntervals` in the `agindin.services.liftosaur-sync` NixOS wrapper module
- Enables hourly automatic syncs on osgiliath (`syncIntervals = "hourly"`)

These changes were accidentally left uncommitted before #49 was merged.

## Test plan
- [ ] `liftosaur-sync-timer-run.timer` active on osgiliath after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)