### PR TITLE
feat(dns): keepalived VRRP floating VIP for DNS failover

### DIFF
--- a/hosts/lorien/services.nix
+++ b/hosts/lorien/services.nix
@@ -79,6 +79,16 @@
       ];
     };
 
+    # Floating DNS VIP (10.88.88.8) shared with osgiliath via keepalived/VRRP.
+    # lorien is the preferred holder (higher priority).
+    dnsFailover = {
+      enable = true;
+      virtualIp = "10.88.88.8/24";
+      interface = "enp1s0";
+      state = "MASTER";
+      priority = 150;
+    };
+
     caddy.enable = true;
 
     postgres.enable = true;

--- a/hosts/osgiliath/services.nix
+++ b/hosts/osgiliath/services.nix
@@ -54,6 +54,16 @@
   agindin.services = {
     blocky.enable = true;
 
+    # Floating DNS VIP (10.88.88.8) shared with lorien via keepalived/VRRP.
+    # osgiliath is the backup holder (lower priority).
+    dnsFailover = {
+      enable = true;
+      virtualIp = "10.88.88.8/24";
+      interface = "eno1";
+      state = "BACKUP";
+      priority = 100;
+    };
+
     postgres.enable = true;
 
     restic = {

--- a/services/blocky.nix
+++ b/services/blocky.nix
@@ -27,7 +27,12 @@ let
     }
   ];
 
-  customDNS = { };
+  customDNS = {
+    # Canary record for the dnsFailover (keepalived) health check. Lets the VRRP
+    # tracking script confirm blocky is answering DNS locally without depending
+    # on upstream reachability. See services/keepalived.nix.
+    "dns-health.local" = "127.0.0.1";
+  };
 
   blacklist = [
     "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"

--- a/services/default.nix
+++ b/services/default.nix
@@ -13,6 +13,7 @@
     ./headache-sync.nix
     ./immich.nix
     ./jellyfin.nix
+    ./keepalived.nix
     ./liftosaur-sync.nix
     ./linkwarden.nix
     ./miniflux.nix

--- a/services/keepalived.nix
+++ b/services/keepalived.nix
@@ -107,24 +107,36 @@ in
     };
     users.groups.${scriptUser} = { };
 
-    # NixOS reverse-path filtering (mangle PREROUTING) drops inbound VRRP
-    # multicast adverts before they reach the filter-table accept or keepalived's
-    # socket, so each node hears only itself and both become MASTER (split brain).
-    # Exempt VRRP (proto 112) from rpfilter; RPF still applies to everything else.
-    # The rpfilter chain is rebuilt on every firewall start, and extraCommands
-    # runs afterwards, so the RETURN is re-inserted each time.
+    # We open the firewall for VRRP ourselves rather than via
+    # services.keepalived.openFirewall, because that module's extraStopCommands
+    # delete their rules without `|| true`. On the first firewall reload after
+    # keepalived is introduced those rules don't exist yet, the delete fails,
+    # and `set -e` aborts the whole reload — so firewall changes silently don't
+    # apply until a manual `systemctl restart firewall`. Our deletes are guarded.
+    #
+    # Two rules are needed for inbound VRRP adverts (proto 112, multicast):
+    #   1. filter: accept them (they'd otherwise hit the default refuse).
+    #   2. mangle: exempt them from reverse-path filtering, which runs first in
+    #      PREROUTING and otherwise drops the multicast before the accept, making
+    #      every node hear only itself and become MASTER (split brain).
+    # ip46tables covers IPv4 and IPv6. The rpfilter/nixos-fw chains are rebuilt
+    # on every firewall start and extraCommands runs afterwards, so both are
+    # re-applied each time.
     networking.firewall = lib.mkIf cfg.openFirewall {
       extraCommands = ''
+        ip46tables -A nixos-fw -p vrrp -j ACCEPT
         ip46tables -t mangle -I nixos-fw-rpfilter -p vrrp -j RETURN
       '';
       extraStopCommands = ''
+        ip46tables -D nixos-fw -p vrrp -j ACCEPT 2>/dev/null || true
         ip46tables -t mangle -D nixos-fw-rpfilter -p vrrp -j RETURN 2>/dev/null || true
       '';
     };
 
     services.keepalived = {
       enable = true;
-      openFirewall = cfg.openFirewall;
+      # Firewall handled above with guarded rules; see the comment there.
+      openFirewall = false;
       # Don't run tracking scripts as root; the store path is root-owned and
       # not writable by non-root, so keepalived accepts it under this policy.
       enableScriptSecurity = true;

--- a/services/keepalived.nix
+++ b/services/keepalived.nix
@@ -107,6 +107,21 @@ in
     };
     users.groups.${scriptUser} = { };
 
+    # NixOS reverse-path filtering (mangle PREROUTING) drops inbound VRRP
+    # multicast adverts before they reach the filter-table accept or keepalived's
+    # socket, so each node hears only itself and both become MASTER (split brain).
+    # Exempt VRRP (proto 112) from rpfilter; RPF still applies to everything else.
+    # The rpfilter chain is rebuilt on every firewall start, and extraCommands
+    # runs afterwards, so the RETURN is re-inserted each time.
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      extraCommands = ''
+        ip46tables -t mangle -I nixos-fw-rpfilter -p vrrp -j RETURN
+      '';
+      extraStopCommands = ''
+        ip46tables -t mangle -D nixos-fw-rpfilter -p vrrp -j RETURN 2>/dev/null || true
+      '';
+    };
+
     services.keepalived = {
       enable = true;
       openFirewall = cfg.openFirewall;

--- a/services/keepalived.nix
+++ b/services/keepalived.nix
@@ -1,0 +1,136 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.agindin.services.dnsFailover;
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
+
+  # Health check for keepalived's VRRP tracking. It resolves a customDNS canary
+  # (see services/blocky.nix) against the *local* blocky, so it verifies that
+  # blocky is actually answering DNS without depending on upstream reachability.
+  # When it fails, keepalived lowers this node's priority by healthCheckWeight,
+  # which must be enough to drop below the peer so the VIP fails over on blocky
+  # death, not only on full node death.
+  # Absolute paths for every binary so the check does not depend on the
+  # (minimal, non-root) environment keepalived runs the tracking script in.
+  checkBlocky = pkgs.writeShellScript "check-blocky" ''
+    ${pkgs.dnsutils}/bin/dig +short +timeout=1 +tries=1 @127.0.0.1 ${cfg.healthCheckDomain} \
+      | ${pkgs.gnugrep}/bin/grep -q '${cfg.healthCheckExpect}'
+  '';
+
+  # Dedicated unprivileged account for the VRRP tracking script. With
+  # enable_script_security, keepalived refuses to run scripts as root, so the
+  # health check runs as this user instead. It only needs to dig localhost.
+  scriptUser = "keepalived-script";
+in
+{
+  options.agindin.services.dnsFailover = {
+    enable = mkEnableOption "keepalived VRRP floating VIP for DNS redundancy";
+
+    virtualIp = mkOption {
+      type = types.str;
+      example = "10.88.88.8/24";
+      description = "Floating virtual IP (with CIDR) shared between the DNS nodes.";
+    };
+
+    interface = mkOption {
+      type = types.str;
+      example = "enp1s0";
+      description = "LAN interface VRRP binds the VIP to. Differs per host.";
+    };
+
+    priority = mkOption {
+      type = types.ints.between 1 254;
+      description = "VRRP priority; the highest-priority reachable node holds the VIP.";
+    };
+
+    state = mkOption {
+      type = types.enum [
+        "MASTER"
+        "BACKUP"
+      ];
+      default = "BACKUP";
+      description = "Initial VRRP state before the first election is held.";
+    };
+
+    virtualRouterId = mkOption {
+      type = types.ints.between 1 255;
+      default = 88;
+      description = "VRRP router id; must match across peers and be unique on the LAN.";
+    };
+
+    healthCheckDomain = mkOption {
+      type = types.str;
+      default = "dns-health.local";
+      description = ''
+        Domain the health check resolves against the local blocky. Must be
+        answerable without upstream reachability (a customDNS canary).
+      '';
+    };
+
+    healthCheckExpect = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "Expected answer for healthCheckDomain; the check passes only if blocky returns it.";
+    };
+
+    healthCheckWeight = mkOption {
+      type = types.int;
+      default = -60;
+      description = ''
+        Priority adjustment applied when the local blocky health check fails.
+        Must be negative enough that this node's priority drops below its peer's,
+        so the VIP fails over when blocky dies (not only when the node dies).
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Open the firewall for VRRP (and AH) packets on this host.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.${scriptUser} = {
+      isSystemUser = true;
+      group = scriptUser;
+      description = "keepalived VRRP tracking script";
+    };
+    users.groups.${scriptUser} = { };
+
+    services.keepalived = {
+      enable = true;
+      openFirewall = cfg.openFirewall;
+      # Don't run tracking scripts as root; the store path is root-owned and
+      # not writable by non-root, so keepalived accepts it under this policy.
+      enableScriptSecurity = true;
+
+      vrrpScripts.check_blocky = {
+        script = "${checkBlocky}";
+        interval = 2;
+        timeout = 2;
+        fall = 2;
+        rise = 2;
+        weight = cfg.healthCheckWeight;
+        user = scriptUser;
+        group = scriptUser;
+      };
+
+      vrrpInstances.dns = {
+        interface = cfg.interface;
+        inherit (cfg) state priority virtualRouterId;
+        virtualIps = [ { addr = cfg.virtualIp; } ];
+        trackScripts = [ "check_blocky" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
## What

Adds an `agindin.services.dnsFailover` module (keepalived/VRRP) so `lorien` and `osgiliath` share a single floating LAN DNS VIP (`10.88.88.8`) instead of being handed out as two separate resolvers. The highest-priority *reachable* node holds the VIP; lorien is MASTER (priority 150), osgiliath BACKUP (100).

Failover triggers on **blocky death**, not just node death: a VRRP tracking script `dig`s a `dns-health.local` customDNS canary against the local blocky, and `weight = -60` drops this node's priority below its peer when the check fails. The script runs as a dedicated unprivileged `keepalived-script` user (not root), gated by `enableScriptSecurity`.

VRRP is LAN-only, so Tailscale keeps handing out both tailnet resolver IPs unchanged. IPv6 VIP was considered and skipped (no stable internal IPv6; IPv4 DNS already resolves AAAA records).

## Commits

- **feat(dns)** — the module + per-host wiring (`lorien` MASTER/`enp1s0`, `osgiliath` BACKUP/`eno1`), plus the blocky `dns-health.local` canary.
- **fix: exempt VRRP from reverse-path filter** — NixOS rpfilter (mangle PREROUTING) dropped inbound VRRP multicast before keepalived's socket, causing split-brain (both MASTER). Exempts proto 112 via `ip46tables`.
- **fix: self-manage VRRP firewall** — upstream `services.keepalived.openFirewall` has unguarded `-D` in its stop-commands, which aborts the firewall *reload* (set -e) the first time keepalived is added, so firewall changes silently don't apply until a manual `systemctl restart firewall`. Opens VRRP ourselves with guarded deletes.

## Testing

- Proven end-to-end in a throwaway `nixosTest` (both blocky-death and node-death failover, plus preempt-back) before touching real hosts.
- `colmena build --on @server` passes for both hosts.
- **Deployed and verified on real hardware**: keepalived converges (lorien holds VIP, osgiliath BACKUP), DNS resolves via `10.88.88.8`, and the unprivileged health check runs.

## Follow-up (out of band, not code)

- UniFi: disable IGMP snooping on the LAN (it pruned the VRRP multicast) — **done**.
- UniFi: hand out `10.88.88.8` as DHCP DNS, kept outside the DHCP pool — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)